### PR TITLE
fix splitter implementation

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -26,13 +26,7 @@ bool split(char s) pure nothrow {
 }
 
 Line toLine(char[] l) pure {
-	return Line(
-		l.byCodePoint.walkLength,
-		l.splitter!(a => a == ' ' || a == '\t')
-			.map!strip
-			.filter!(l => !l.empty)
-			.walkLength
-		);
+	return Line(l.byCodePoint.walkLength, l.splitter.walkLength);
 }
 
 void main(string[] args) {


### PR DESCRIPTION
splitter with no arguments splits words delimited by multiple whitespaces by default.
Before there was a bug not properly removing all whitespaces because only space and tab was counted.
This now reports the same count as `wc` for the source/app.d itself.

You might need to redo your benchmarks for D now though